### PR TITLE
[43기 장지아] MODIFY : Nav 폰트 사이즈 충돌 문제 해결

### DIFF
--- a/src/components/Nav/Nav.scss
+++ b/src/components/Nav/Nav.scss
@@ -28,7 +28,7 @@
     .navText {
       display: flex;
       align-items: center;
-      font-size: 1rem;
+      font-size: 1.5rem;
       font-weight: 400;
 
       .navTextList {
@@ -46,7 +46,7 @@
         display: flex;
         align-items: center;
         margin-left: 25px;
-        font-size: 1rem;
+        font-size: 1.5rem;
       }
 
       .searchContainer {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 폰트 사이즈 충돌 문제 해결

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. reset.scss 설정 변경으로 인해 nav bar의 text 및 icon의 font size가 일정 비율 줄어드는 문제가 있어 수정했습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 프론트엔드 내에서 논의한 규칙에 따라 폰트 사이즈를 rem 단위로 관리하고 있는데, 아직 해당 방식이 익숙치 않아 적응하고 있습니다.

<br />

## :: 기타 질문 및 특이 사항
- 
